### PR TITLE
Fix xml validation error in plugin.xml

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -8,7 +8,7 @@
     <compatibility minVersion="5.3.0" />
     <changelog version="2.2.4">
 		<changes lang="en">
-        	Fixed some Bug in klarna-payments & paypal.
+        	Fixed some Bug in klarna-payments and paypal.
 		</changes>
 	</changelog>
     <changelog version="2.2.3">


### PR DESCRIPTION
If you download the latest commit, zip it and try to install it manually, shopware throws an error at you about failing to validate some XML.
Turns out, that whatever tries to validate plugin.xml, does not like ampersands (&) in text-sections, it tries to parse it as a reference.